### PR TITLE
Show backend array class in ImageArray show method

### DIFF
--- a/R/ImageArray.R
+++ b/R/ImageArray.R
@@ -139,11 +139,27 @@ setMethod(
 )
 
 #' @importFrom S4Vectors coolcat
+#' @importFrom DelayedArray seed
 #' @noRd
 setMethod(
   f = "show",
   signature = c("ImageArray"),
   definition = function(object) {
+    # Determine backend label from the first level array
+    first_level <- object[[1]]
+    backend_class <- class(first_level)
+
+    backend_label <- if (backend_class == "BFArray") {
+      # For BFArray, include the file extension (e.g. ".ome.tiff")
+      tryCatch({
+        fp <- DelayedArray::seed(first_level)@filepath
+        ext <- sub("^[^.]*", "", basename(fp))
+        if (nzchar(ext)) paste0(backend_class, ", ", ext) else backend_class
+      }, error = function(e) backend_class)
+    } else {
+      backend_class
+    }
+
     cat(
       class(x = object),
       "Object",
@@ -152,6 +168,7 @@ setMethod(
         paste(axes(object), collapse = ","),
         ")"
       ),
+      paste0("[", backend_label, "]"),
       "\n"
     )
     scales <- sprintf(

--- a/tests/testthat/test-imagearray-class.R
+++ b/tests/testthat/test-imagearray-class.R
@@ -19,3 +19,30 @@ test_that("image array class", {
                                          array(1:75, dim = c(3,6,6,2))))
   )
 })
+
+test_that("show method displays backend class label", {
+  library(EBImage)
+  img.file <- system.file("images", "sample.png", package = "EBImage")
+
+  # in-memory: shows DelayedArray (use magick engine to get RGB / 3D array)
+  imgarray <- createImageArray(img.file, n.levels = 2, engine = "magick-image")
+  expect_output(show(imgarray), "\\[DelayedArray\\]")
+  expect_output(show(imgarray), "ImageArray Object")
+  expect_output(show(imgarray), "Scales \\(2\\):")
+
+  # HDF5: shows HDF5Array
+  output_h5 <- tempfile(fileext = ".h5")
+  imgarray_h5 <- writeImageArray(img.file, output = output_h5,
+                                 name = "image", format = "h5",
+                                 n.levels = 2, engine = "magick-image",
+                                 verbose = FALSE)
+  expect_output(show(imgarray_h5), "\\[HDF5Array\\]")
+
+  # Zarr: shows ZarrArray
+  output_zarr <- tempfile(fileext = ".zarr")
+  imgarray_zarr <- writeImageArray(img.file, output = output_zarr,
+                                   name = "image", format = "zarr",
+                                   n.levels = 2, engine = "magick-image",
+                                   verbose = FALSE)
+  expect_output(show(imgarray_zarr), "\\[ZarrArray\\]")
+})


### PR DESCRIPTION
## Summary

Closes #39.

- Updated the `show` method for `ImageArray` objects to display the underlying array backend in brackets after the axes label (e.g. `[HDF5Array]`, `[ZarrArray]`, `[BFArray, .ome.tiff]`).
- The backend class is derived via `class()` on the first pyramid level; for `BFArray` the compound file extension (e.g. `.ome.tiff`) is additionally extracted from the seed filepath.

**Before:**
```
ImageArray Object (c,x,y)
Scales (2): (3,768,512) (3,384,256)
```

**After:**
```
ImageArray Object (c,x,y) [ZarrArray]
Scales (2): (3,768,512) (3,384,256)
```

## Test plan

- [ ] New `test_that("show method displays backend class label")` in `tests/testthat/test-imagearray-class.R` covers in-memory (`DelayedArray`), HDF5 (`HDF5Array`), and Zarr (`ZarrArray`) backends.
- [ ] Full test suite passes (138 tests, 0 failures).
- [ ] BFArray path (`.ome.tiff` extension display) is handled via `tryCatch` — tested manually with the package's bundled `.ome.tiff` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)